### PR TITLE
webkit issues, and other bugs.

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -155,10 +155,6 @@
     font-weight: 700;
   }
 
-  .d-block{
-    display: block;
-  }
-
   .tns-liveregion.tns-visually-hidden {
     display: none;
   }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -89,30 +89,50 @@
 </script>
 
 <style lang="scss" global>
-  body,
-  html {
-    height: 100%;
-    overflow-x: hidden;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    background: black;
-    color: white;
+
+  html, body{
     margin: 0;
     padding: 0;
-    font-family: "GT Pressura Mono", "Basis Grotesque Pro", "Akkurat-Mono",
-      monospace;
+    height: 100%;
+    overflow-x: hidden;
     scroll-behavior: smooth;
+
     &.no-scroll {
       overflow: hidden;
     }
   }
 
+  body{
+    text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
+
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -ms-overflow-style: scrollbar;
+
+    font-smoothing: antialiased;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+
+    font-variant-ligatures: common-ligatures;
+    font-feature-settings: 'liga';
+
+    background-color: #000;
+    color: #FFF;
+    margin: 0;
+    padding: 0;
+    font-family: "GT Pressura Mono", "Basis Grotesque Pro", "Akkurat-Mono", monospace;
+  }
+
   *,
-  *:before,
-  *:after {
+  *::before,
+  *::after {
     box-sizing: border-box;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   }
+
+  ::-webkit-scrollbar {width: 0px;}
 
   a {
     text-decoration: none;
@@ -124,17 +144,19 @@
   }
 
   ::selection {
-    background: #e4e4e4;
-    /* WebKit/Blink Browsers */
+    background-color: #e4e4e4;
   }
 
   ::-moz-selection {
-    background: #e4e4e4;
-    /* Gecko Browsers */
+    background-color: #e4e4e4;
   }
 
   strong {
     font-weight: 700;
+  }
+
+  .d-block{
+    display: block;
   }
 
   .tns-liveregion.tns-visually-hidden {
@@ -142,17 +164,35 @@
   }
 
   .pane img {
-    max-width: 90vw;
-    height: 400px;
+    width: auto;
+    max-height: 400px;
+    max-width: calc(100% - 2rem);
   }
 
   .pane figure {
     padding-left: 0;
     margin-left: 0;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
   }
 
+    .pane figure img{
+      max-width: 100%;
+      height: auto;
+    }
+
+
   .pane p {
-    max-width: 80ch;
+    font-size: 16px;
+    font-weight: normal;
+    line-height: 1.333;
+    max-width: 39.292rem;
+  }
+
+  .pane.introduction p {
+    font-size: 21.33px;
+    line-height: 1.333;
+    font-weight: 300;
   }
 
   .pane a {
@@ -165,17 +205,6 @@
   video {
     max-width: 100vw;
   }
-
-  // .subtitle-box {
-  //   position: fixed;
-  //   top: 0;
-  //   left: 0;
-  //   background: yellow;
-  //   font-size: 34px;
-  //   z-index: 100000;
-  //   height: 400px;
-  //   width: 300px;
-  // }
 
   img {
     max-width: 100vw;

--- a/src/CycleOne.svelte
+++ b/src/CycleOne.svelte
@@ -67,91 +67,20 @@
 </script>
 
 <style lang="scss">
-  .text {
-    max-width: 800px;
-    margin-left: auto;
-    margin-right: auto;
-    font-size: 18px;
-    padding-bottom: 120px;
-    font-weight: 300;
-  }
-
-  @keyframes sweep {
-    0% {
-      clip-path: inset(0% 0% 0% 100%);
-      -webkit-clip-path: inset(0% 0% 0% 100%);
-    }
-    50% {
-      clip-path: inset(0% 0% 0% 0%);
-      -webkit-clip-path: inset(0% 0% 0% 0%);
-    }
-    100% {
-      clip-path: inset(0% 100% 0% 0%);
-      -webkit-clip-path: inset(0% 100% 0% 0%);
-    }
-  }
-
-  @keyframes sweep-mobile {
-    0% {
-      clip-path: inset(0% 0% 100% 0%);
-    }
-    50% {
-      clip-path: inset(0% 0% 0% 0%);
-    }
-    100% {
-      clip-path: inset(100% 0% 0% 0%);
-    }
-  }
-
-  #contain {
-    height: 400px;
-    width: 100vw;
-    position: relative;
-  }
-
-  .logo2 {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    font-size: 22vw;
-    line-height: 150px;
-    transform: translateX(-50%) translateY(-50%) scale(1);
-  }
-
-  .about {
-    min-height: 100vh;
-    width: 100vw;
-    background: blue;
-    padding-top: 120px;
-    padding-bottom: 300px;
-
-    p,
-    h1 {
-      display: block;
-      width: 70ch;
-      max-width: 90vw;
-      margin-right: auto;
-      margin-left: auto;
-      font-size: 22px;
-      color: black;
-      font-weight: 300;
-      &.small {
-        font-size: 16px;
-      }
-    }
-
-    h1 {
-      font-size: 90px;
-      font-weight: 500;
-    }
-  }
+@import "./variables.scss";
+.paneContainer {
+  min-height: 100%;
+  height: 100%;
+  width: 100%;
+  background-color: blue;
+}
 </style>
 
 <svelte:head>
   <title>Cycle 1 | LIQUID FICTION</title>
 </svelte:head>
 
-<div class="about">
+<div class="paneContainer">
   {#each textList as text, order}
     <Pane
       on:activated={event => {

--- a/src/Editorial.svelte
+++ b/src/Editorial.svelte
@@ -68,91 +68,20 @@
 </script>
 
 <style lang="scss">
-  .text {
-    max-width: 800px;
-    margin-left: auto;
-    margin-right: auto;
-    font-size: 18px;
-    padding-bottom: 120px;
-    font-weight: 300;
-  }
-
-  @keyframes sweep {
-    0% {
-      clip-path: inset(0% 0% 0% 100%);
-      -webkit-clip-path: inset(0% 0% 0% 100%);
-    }
-    50% {
-      clip-path: inset(0% 0% 0% 0%);
-      -webkit-clip-path: inset(0% 0% 0% 0%);
-    }
-    100% {
-      clip-path: inset(0% 100% 0% 0%);
-      -webkit-clip-path: inset(0% 100% 0% 0%);
-    }
-  }
-
-  @keyframes sweep-mobile {
-    0% {
-      clip-path: inset(0% 0% 100% 0%);
-    }
-    50% {
-      clip-path: inset(0% 0% 0% 0%);
-    }
-    100% {
-      clip-path: inset(100% 0% 0% 0%);
-    }
-  }
-
-  #contain {
-    height: 400px;
-    width: 100vw;
-    position: relative;
-  }
-
-  .logo2 {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    font-size: 22vw;
-    line-height: 150px;
-    transform: translateX(-50%) translateY(-50%) scale(1);
-  }
-
-  .about {
-    min-height: 100vh;
-    width: 100vw;
-    background: blue;
-    padding-top: 120px;
-    padding-bottom: 300px;
-
-    p,
-    h1 {
-      display: block;
-      width: 70ch;
-      max-width: 90vw;
-      margin-right: auto;
-      margin-left: auto;
-      font-size: 22px;
-      color: blue;
-      font-weight: 300;
-      &.small {
-        font-size: 16px;
-      }
-    }
-
-    h1 {
-      font-size: 90px;
-      font-weight: 500;
-    }
-  }
+@import "./variables.scss";
+.paneContainer {
+  min-height: 100%;
+  height: 100%;
+  width: 100%;
+  background-color: blue;
+}
 </style>
 
 <svelte:head>
   <title>Editorial | LIQUID FICTION</title>
 </svelte:head>
 
-<div class="about">
+<div class="paneContainer">
   {#each textList as text, order}
     <Pane
       on:activated={event => {

--- a/src/Landing.svelte
+++ b/src/Landing.svelte
@@ -37,73 +37,54 @@
 </script>
 
 <style lang="scss">
-  $col: blue;
+@import "./variables.scss";
+.logo2 {
+  position: absolute;
+  top: 50%;
+  left: 50%;
 
-  .logo2 {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    font-size: 22vw;
-    line-height: 150px;
-    transform: translateX(-50%) translateY(-50%) scale(1);
-  }
+  transform: translate(-50%, -50%) scale(1);
+  font-size: 22vw;
+  line-height: 22vw;
+}
 
-  @keyframes sweep {
-    0% {
-      clip-path: inset(0% 0% 0% 100%);
-      -webkit-clip-path: inset(0% 0% 0% 100%);
-    }
-    50% {
-      clip-path: inset(0% 0% 0% 0%);
-      -webkit-clip-path: inset(0% 0% 0% 0%);
-    }
-    100% {
-      clip-path: inset(0% 100% 0% 0%);
-      -webkit-clip-path: inset(0% 100% 0% 0%);
-    }
-  }
+.pane {
+  position: absolute;
 
-  @keyframes sweep-mobile {
-    0% {
-      clip-path: inset(0% 0% 100% 0%);
-    }
-    50% {
-      clip-path: inset(0% 0% 0% 0%);
-    }
-    100% {
-      clip-path: inset(100% 0% 0% 0%);
-    }
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  width: 100%;
+  height: 100%;
+
+  font-weight: 200;
+  cursor: pointer; 
+}
+
+.pane.top-left {
+    background-color: #000;
+    color: blue; 
+}
+
+.pane.top-right {
+    z-index: 100;
+    background-color: blue;
+}
+
+@media (max-width: 768px){
+  .pane.top-right {
+  -webkit-animation: sweepMobile 7s ease-out infinite normal;
+          animation: sweepMobile 7s ease-out infinite normal;    
   }
-  .pane {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    font-weight: 200;
-    cursor: pointer;
-    &.top-left {
-      background: black;
-      color: $col;
-    }
-    &.top-right {
-      z-index: 100;
-      background: $col;
-      clip-path: inset(0% 0% 0% 100%);
-      animation-name: sweep;
-      animation-duration: 5s;
-      animation-timing-function: easeOut;
-      animation-iteration-count: infinite;
-      animation-direction: alternate;
-      @media only screen and (max-width: 700px) {
-        animation-name: sweep-mobile;
-        animation-duration: 7s;
-        animation-timing-function: easeOut;
-        animation-iteration-count: infinite;
-        animation-direction: normal;
-      }
-    }
+}
+@media (min-width: 768px){
+  .pane.top-right {
+  -webkit-animation: sweep 5s ease-out infinite alternate;
+          animation: sweep 5s ease-out infinite alternate;
   }
+}
 </style>
 
 <svelte:head>

--- a/src/Menu.svelte
+++ b/src/Menu.svelte
@@ -24,194 +24,154 @@
     menuActive.set(active);
   }
 
+  // const handleExit = () => {
+  //   exit = true;
+  //   setTimeout(() => {
+  //     exit = false;
+  //   }, 1000);
+  // };
+
   // *** VARIABLES
   export let active = false;
   const dispatch = createEventDispatcher();
-
-  function startVideos() {
-    // 1s buffer
-    setTimeout(function(){
-          document.querySelectorAll("video").forEach(e => {
-              e.play()
-          })
-    }, 1000);
-  }
-
+  // export let exit = false;
 </script>
 
 <style lang="scss">
-  @import "./variables.scss";
+@import "./variables.scss";
 
-  @keyframes sweep {
-    0% {
-      clip-path: inset(0% 0% 0% 100%);
-      -webkit-clip-path: inset(0% 0% 0% 100%);
-    }
-    50% {
-      clip-path: inset(0% 0% 0% 0%);
-      -webkit-clip-path: inset(0% 0% 0% 0%);
-    }
-    100% {
-      clip-path: inset(0% 100% 0% 0%);
-      -webkit-clip-path: inset(0% 100% 0% 0%);
-    }
-  }
+.menu {
+  line-height: 62px;
+  position: fixed;
+  z-index: 99999;
+  top: 0;
+  top: 0;
+  right: 0;
+  left: 0;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  padding-top: 80px;
+  transition: -webkit-clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+  transition: clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+  transition: clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1), -webkit-clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+  opacity: 1;
+  background-color: blue;
+  clip-path: inset(0% 100% 0% 0%);
+  -webkit-clip-path: inset(0% 100% 0% 0%); }
 
+.menu .inner .item {
+  font-size: 90px;
+  cursor: pointer;
+  line-height: 80px;
+  position: relative;
+  display: inline-block;
+  display: inline-block;
+  width: 100%;
+  height: 80px;
+  margin-bottom: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  text-transform: uppercase;
+  clip-path: inset(0% 0% 0% 0%);
+  -webkit-clip-path: inset(0% 0% 0% 0%); }
+
+
+@media (max-width: 700px) {
   .menu {
-    position: fixed;
-    padding-top: 80px;
-    z-index: 101;
-    width: 100vw;
-    height: 100vh;
-    top: 0px;
-    left: 0px;
-    background: rgba(0, 0, 255, 1);
-    clip-path: inset(0% 100% 0% 0%);
-    -webkit-clip-path: inset(0% 100% 0% 0%);
-    transition: clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1);
-    opacity: 1;
-    overflow: auto;
-    line-height: 62px;
+    padding-top: 120px; }
 
-    @include screen-size("small") {
-      padding-top: 120px;
-    }
+  .menu .inner .item {
+    font-size: 42px;
+    line-height: 45px;
+    height: 40px; } }
+.menu .inner .item .line-1,
+.menu .inner .item .line-2 {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  text-align: right;
+  white-space: nowrap;
+  color: #fff; }
 
-    .inner {
-      .item {
-        display: inline-block;
-        width: 100%;
-        margin-bottom: 0;
-        height: 80px;
-        display: inline-block;
-        text-transform: uppercase;
-        clip-path: inset(0% 0% 0% 0%);
-        -webkit-clip-path: inset(0% 0% 0% 0%);
-        position: relative;
-        font-size: 90px;
+.menu .inner .item .line-1 {
+  z-index: 1;
+  opacity: 1; }
 
-        user-select: none;
+.menu .inner .item .line-2 {
+  z-index: 2;
+  background-color: blue;
+  clip-path: inset(0% 0% 0% 100%);
+  -webkit-clip-path: inset(0% 0% 0% 100%); }
 
-        @include screen-size("small") {
-          font-size: 42px;
-          height: 40px;
-        }
+.menu .inner .item:hover .line-2 {
+  -webkit-animation: sweep 2s linear infinite alternate;
+          animation: sweep 2s linear infinite alternate; }
 
-        .line-1 {
-          position: absolute;
-          top: 0;
-          left: 50%;
-          z-index: 1;
-          color: white;
-          transform: translateX(-50%);
-          opacity: 1;
-          text-align: right;
-          line-height: 80px;
-          white-space: nowrap;
+.menu.active {
+  transition: -webkit-clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+  transition: clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+  transition: clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1), -webkit-clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+  clip-path: inset(0% 0% 0% 0%);
+  -webkit-clip-path: inset(0% 0% 0% 0%); }
 
-          @include screen-size("small") {
-            line-height: 45px;
-          }
-        }
+.menu.exit {
+  transition: -webkit-clip-path 0.5s cubic-bezier(0.23, 1, 0.32, 1);
+  transition: clip-path 0.5s cubic-bezier(0.23, 1, 0.32, 1);
+  transition: clip-path 0.5s cubic-bezier(0.23, 1, 0.32, 1), -webkit-clip-path 0.5s cubic-bezier(0.23, 1, 0.32, 1);
+  clip-path: inset(0% 0% 0% 100%);
+  -webkit-clip-path: inset(0% 0% 0% 100%); }
 
-        .line-2 {
-          position: absolute;
-          top: 0;
-          left: 50%;
-          z-index: 2;
-          color: #0000ff;
-          clip-path: inset(0% 0% 0% 100%);
-          -webkit-clip-path: inset(0% 0% 0% 100%);
-          transform: translateX(-50%);
-          text-align: right;
-          background: blue;
-          color: white;
-          // padding-bottom: 15px;
-          line-height: 80px;
-          white-space: nowrap;
+.close {
+  font: inherit;
+  font-size: 72px;
+  line-height: normal;
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  display: block;
+  overflow: visible;
+  width: auto;
+  margin: 0;
+  padding: 0;
+  padding: 30px;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  -webkit-font-smoothing: inherit;
+  -moz-osx-font-smoothing: inherit;
+  -webkit-appearance: none;
+  width: 60px;
+  height: 60px; }
 
-          @include screen-size("small") {
-            line-height: 45px;
-          }
-        }
+.menu.active .close svg {
+  transition: transform 1000ms cubic-bezier(0.23, 1, 0.32, 1), fill 200ms ease;
+  transform: rotate(180deg) scale(1); }
 
-        &:hover {
-          .line-2 {
-            animation-name: sweep;
-            animation-duration: 2s;
-            animation-timing-function: linear;
-            animation-iteration-count: infinite;
-            animation-direction: alternate;
-            animation-direction: reverse;
-          }
-        }
-      }
-    }
+.close svg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: block;
+  margin-top: -20px;
+  margin-left: -20px;
+  transition: transform 500ms cubic-bezier(0.23, 1, 0.32, 1), fill 200ms ease;
+  transform: rotate(0deg) scale(0);
+  width: 40px;
+  height: 40px;
+  fill: #fff; }
 
-    .close {
-      position: absolute;
-      top: 27px;
-      left: 27px;
-      width: 60px;
-      height: 60px;
-      padding: 30px;
-      font-size: 72px;
-      color: white;
-      text-align: center;
-      border-radius: 60px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      cursor: pointer;
+.close:hover svg,
+.close:focus svg,
+.close:active svg {
+  fill: #000; }
 
-      svg {
-        height: 40px;
-        width: 40px;
-        position: relative;
-        top: -5px;
-
-        transform: rotate(0deg) scale(0);
-        transition: transform 0.5s cubic-bezier(0.23, 1, 0.32, 1);
-
-        .cls-1 {
-          fill: none;
-        }
-
-        .cls-2 {
-          clip-path: url(#clip-path);
-        }
-
-        .cls-3 {
-          fill: white;
-        }
-      }
-
-      &:hover {
-        svg {
-          color: black;
-        }
-      }
-    }
-
-    &.active {
-      clip-path: inset(0% 0% 0% 0%);
-      -webkit-clip-path: inset(0% 0% 0% 0%);
-      transition: clip-path 0.3s cubic-bezier(0.23, 1, 0.32, 1);
-
-      .close {
-        svg {
-          transform: rotate(180deg) scale(1);
-          transition: transform 1s cubic-bezier(0.23, 1, 0.32, 1);
-        }
-      }
-    }
-
-    &.exit {
-      transition: clip-path 0.5s cubic-bezier(0.23, 1, 0.32, 1);
-      clip-path: inset(0% 0% 0% 100%);
-      -webkit-clip-path: inset(0% 0% 0% 100%);
-    }
-  }
+.close:focus,
+.close:active {
+  outline: 0; }
 </style>
 
 <div
@@ -222,7 +182,7 @@
   }}>
 
   <Router>
-    <div class="inner">
+    <nav class="inner" role="navigation">
       {#if active}
         <div
           class="item"
@@ -253,7 +213,6 @@
         </div>
         <div
           class="item"
-          on:click={() => { startVideos(); }}
           in:fly={{ duration: 400, y: 20, delay: 300, easing: quartOut }}
           out:fly={{ duration: 300, y: 60, delay: 200 }}>
           <Link to="alina-chaiderov">
@@ -282,33 +241,14 @@
           </Link>
         </div>
       {/if}
-    </div>
+    </nav>
   </Router>
 
-  <div class="close">
-    <div class="inner-1">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-        viewBox="0 0 55.46 55.39">
-        <defs>
-          <clipPath id="clip-path" transform="translate(-1.08 -0.65)">
-            <rect
-              class="cls-1"
-              x="1.08"
-              y="0.65"
-              width="55.46"
-              height="55.39" />
-          </clipPath>
-        </defs>
-        <title>cross</title>
-        <g class="cls-2">
-          <path
-            class="cls-3"
-            d="M2.12,49a3.91,3.91,0,0,0-1,2.4,3.08,3.08,0,0,0,1,2.41l1.23,1.23A3.37,3.37,0,0,0,5.69,56a3.12,3.12,0,0,0,2.47-.89L27.38,35.59a1.55,1.55,0,0,1,2.47,0L49.34,54.94A3,3,0,0,0,51.67,56a3.37,3.37,0,0,0,2.47-1.1l1.38-1.23a2.88,2.88,0,0,0,1-2.4,3.62,3.62,0,0,0-1-2.41L36,29.41a1.55,1.55,0,0,1,0-2.47L55.52,7.72a3.18,3.18,0,0,0,.89-2.47,3.45,3.45,0,0,0-.89-2.33L54.28,1.68a3.2,3.2,0,0,0-2.47-1,3.44,3.44,0,0,0-2.33,1L30,20.9a1.4,1.4,0,0,1-2.33,0L8.16,1.68a2.84,2.84,0,0,0-2.27-1,3.51,3.51,0,0,0-2.54,1.1L2.12,2.92a3.21,3.21,0,0,0-1,2.54,3.48,3.48,0,0,0,1,2.4L21.34,27.22a1.66,1.66,0,0,1,0,2.47Z"
-            transform="translate(-1.08 -0.65)" />
-        </g>
-      </svg>
-    </div>
-  </div>
+<button role="button" class="close">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 55.46 55.39">
+        <path d="M1.04 48.35a3.91 3.91 0 00-1 2.4 3.08 3.08 0 001 2.41l1.23 1.23a3.37 3.37 0 002.34.96 3.12 3.12 0 002.47-.89L26.3 34.94a1.55 1.55 0 012.47 0l19.49 19.35a3 3 0 002.33 1.06 3.37 3.37 0 002.47-1.1l1.38-1.23a2.88 2.88 0 001-2.4 3.62 3.62 0 00-1-2.41L34.92 28.76a1.55 1.55 0 010-2.47L54.44 7.07a3.18 3.18 0 00.89-2.47 3.45 3.45 0 00-.89-2.33L53.2 1.03a3.2 3.2 0 00-2.47-1 3.44 3.44 0 00-2.33 1L28.92 20.25a1.4 1.4 0 01-2.33 0L7.08 1.03a2.84 2.84 0 00-2.27-1 3.51 3.51 0 00-2.54 1.1L1.04 2.27a3.21 3.21 0 00-1 2.54 3.48 3.48 0 001 2.4l19.22 19.36a1.66 1.66 0 010 2.47z"/>
+    </svg>
+    <span class="sr-only">Close Menu</span>
+</button>
+
 </div>

--- a/src/Menu.svelte
+++ b/src/Menu.svelte
@@ -107,6 +107,7 @@
   clip-path: inset(0% 0% 0% 100%);
   -webkit-clip-path: inset(0% 0% 0% 100%); }
 
+// !todo add :focus event inside `Link` component
 .menu .inner .item:hover .line-2 {
   -webkit-animation: sweep 2s linear infinite alternate;
           animation: sweep 2s linear infinite alternate; }

--- a/src/Orb.svelte
+++ b/src/Orb.svelte
@@ -54,6 +54,19 @@
 @import "./variables.scss";
 
 .orb {
+  border: none;
+  margin: 0;
+  padding: 0;
+  width: auto;
+  overflow: visible;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  -webkit-font-smoothing: inherit;
+  -moz-osx-font-smoothing: inherit;
+  -webkit-appearance: none;
+
   z-index: 999;
   position: fixed;
   top: 10px;
@@ -70,6 +83,11 @@
   cursor: pointer;
   opacity: 0.9;
   transition: opacity 3s cubic-bezier(0.23, 1, 0.32, 1), border 0.3s cubic-bezier(0.23, 1, 0.32, 1), transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.orb:focus,
+.orb:active{
+  outline: 0;
 }
 
 .orb:hover { opacity: 1; }
@@ -156,7 +174,8 @@
 
 </style>
 
-<div
+<button
+  role="button"
   class="orb"
   class:inactive={$menuActive}
   class:hidden={$activePage === 'landing'}
@@ -171,7 +190,10 @@
   <div id="spinner" class="spinner" class:scrolling>
     <div class="spinner-half" />
   </div>
-</div>
+  <span class="sr-only">Open menu</span>
+</button>
+
+
 <Menu
   active={$menuActive}
   on:close={() => {

--- a/src/Orb.svelte
+++ b/src/Orb.svelte
@@ -31,11 +31,11 @@
 
   $: {
     TweenMax.to(orbInnerOne, 0.1, {
-      css: { background: $orbBackgroundOne, color: $orbColorOne }
+      css: { backgroundColor: $orbBackgroundOne, color: $orbColorOne }
     });
 
     TweenMax.to(orbInnerTwo, 0.1, {
-      css: { background: $orbBackgroundTwo, color: $orbColorTwo }
+      css: { backgroundColor: $orbBackgroundTwo, color: $orbColorTwo }
     });
 
     TweenMax.to(orbObject, 2, {
@@ -51,128 +51,109 @@
 </script>
 
 <style lang="scss">
-  @keyframes sweep2 {
-    0% {
-      clip-path: inset(0% 100% 0% 0%);
-    }
-    50% {
-      clip-path: inset(0% 0% 0% 0%);
-    }
-    100% {
-      clip-path: inset(0% 0% 0% 100%);
-    }
+@import "./variables.scss";
+
+.orb {
+  z-index: 999;
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  padding: 30px;
+  width: 100px;
+  height: 100px;
+  line-height: 100px;
+  font-size: 18px;
+  color: white;
+  text-align: center;
+  border-radius: 80px;
+  overflow: hidden;
+  cursor: pointer;
+  opacity: 0.9;
+  transition: opacity 3s cubic-bezier(0.23, 1, 0.32, 1), border 0.3s cubic-bezier(0.23, 1, 0.32, 1), transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.orb:hover { opacity: 1; }
+.orb.hidden {display: none;}
+
+.orb .nav-text {
+  opacity: 1;
+  transition: opacity 1s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.orb .nav-text.scrolling {
+    opacity: 0;
+    transition: opacity 1s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.orb .inner-1 {
+  z-index: 2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #0000ff;
+  color: white;
+  text-align: center; }
+
+.orb .inner-2 {
+  position: absolute;
+  z-index: 3;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  color: white;
+  text-align: center;
+  -webkit-clip-path: inset(0 0 100% 0);
+          clip-path: inset(0 0 100% 0);
+
+-webkit-animation: sweepTwo 6s linear infinite;
+        animation: sweepTwo 6s linear infinite;
+  color: #000; }
+
+.orb .spinner {
+  position: absolute;
+  z-index: 4;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 100px;
+  background: darkorange;
+  opacity: 0; }
+
+.orb .spinner .spinner-half {
+  position: absolute;
+  z-index: 4;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: darkgoldenrod;
+  color: white;
+  text-align: center;
+  -webkit-clip-path: inset(0 50% 0% 0);
+          clip-path: inset(0 50% 0% 0); }
+
+.orb .spinner.scrolling {
+  opacity: 1;
+  transition: opacity 0.5s cubic-bezier(0.23, 1, 0.32, 1);
+  -webkit-clip-path: inset(0 0 0 0);
+          clip-path: inset(0 0 0 0); }
+
+.orb.inactive {
+  transform: scale(0);
+  -webkit-clip-path: inset(0 100% 0 0);
+          clip-path: inset(0 100% 0 0);
   }
 
-  .orb {
-    z-index: 999;
-    position: fixed;
-    top: 10px;
-    left: 10px;
-    padding: 30px;
-    width: 100px;
-    height: 100px;
-    line-height: 100px;
-    font-size: 18px;
-    color: white;
-    text-align: center;
-    border-radius: 80px;
-    overflow: hidden;
-    cursor: pointer;
-    opacity: 0.9;
+.orb.inactive .inner-2 {
+    -webkit-animation-name: unset;
+            animation-name: unset;
+}
 
-    .nav-text {
-      opacity: 1;
-      transition: opacity 1s cubic-bezier(0.23, 1, 0.32, 1);
-      &.scrolling {
-        opacity: 0;
-        transition: opacity 1s cubic-bezier(0.23, 1, 0.32, 1);
-      }
-    }
 
-    .inner-1 {
-      z-index: 2;
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: #0000ff;
-      color: white;
-      text-align: center;
-    }
-
-    .inner-2 {
-      position: absolute;
-      z-index: 3;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      // background: #0000ff;
-      color: white;
-      text-align: center;
-      clip-path: inset(0 0 100% 0);
-      animation-name: sweep2;
-      animation-duration: 6s;
-      animation-timing-function: linear;
-      animation-iteration-count: infinite;
-      // animation-direction: alternate;
-      // animation-direction: reverse;
-      color: black;
-    }
-
-    .spinner {
-      position: absolute;
-      z-index: 4;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      border-radius: 100px;
-      background: darkorange;
-      opacity: 0;
-      .spinner-half {
-        position: absolute;
-        z-index: 4;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: darkgoldenrod;
-        color: white;
-        text-align: center;
-        clip-path: inset(0 50% 0% 0);
-      }
-
-      &.scrolling {
-        opacity: 1;
-        transition: opacity 0.5s cubic-bezier(0.23, 1, 0.32, 1);
-        clip-path: inset(0 0 0 0);
-      }
-    }
-
-    transition: opacity 3s cubic-bezier(0.23, 1, 0.32, 1),
-      border 0.3s cubic-bezier(0.23, 1, 0.32, 1),
-      transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
-
-    &:hover {
-      opacity: 1;
-    }
-
-    &.inactive {
-      transform: scale(0);
-
-      clip-path: inset(0 100% 0 0);
-
-      .inner-2 {
-        animation-name: unset;
-      }
-    }
-
-    &.hidden {
-      display: none;
-    }
-  }
 </style>
 
 <div

--- a/src/Pane.svelte
+++ b/src/Pane.svelte
@@ -99,11 +99,7 @@
     transform: translateX(100%) !important;
 }
 
-.pane.introduction p {
-  font-size: 21.33px;
-  line-height: 1.333;
-  font-weight: normal;
-}
+
 
 .close {
   font: inherit;
@@ -158,7 +154,6 @@
 .pane:not(.active) + .close{opacity: 0;}
 </style>
 
-  <div class="close" on:click={close}>
 <section class="paneSection">
   <div
     class="pane"

--- a/src/Pane.svelte
+++ b/src/Pane.svelte
@@ -11,6 +11,7 @@
   import { quartOut } from "svelte/easing";
   import { renderBlockText, urlFor } from "./sanity.js";
   import { createEventDispatcher } from "svelte";
+  import { fade } from "svelte/transition";
 
   const dispatch = createEventDispatcher();
 
@@ -40,141 +41,140 @@
   $: left = active ? 0 : ((100 - width) / (totalPanes - 1)) * order;
 
   const open = () => {
-    // active = !active;
-    if (active) {
-      dispatch("activated", {
-        order: 1000
-      });
-    } else {
-      dispatch("activated", {
-        order: order
-      });
-    }
+      // active = !active;
+    dispatch("activated", {
+          order: order
+        });
   };
 
   const close = () => {
     dispatch("activated", {
       order: 1000
     });
+    // if (active) {
+    //   dispatch("activated", {
+    //     order: 1000
+    //   });
+    // } else {
+    //   dispatch("activated", {
+    //     order: order
+    //   });
+    // }
   };
 </script>
 
 <style lang="scss">
-  .pane {
-    position: fixed;
-    top: 0;
-    right: 0;
-    width: 100vw;
-    height: 100vh;
-    width: 100vw;
-    padding: 30px;
-    padding-top: 50px;
-    cursor: pointer;
-    transition: transform 0.3s ease-out;
-    overflow-y: auto;
-    line-height: 1.2em;
-    font-size: 17px;
-    color: black;
-    padding-bottom: 40px;
+@import "./variables.scss";
 
-    &.active {
-      cursor: default;
-      transform: translateX(0vw);
-    }
 
-    &.hidden {
-      transition: transform 0.3s ease-out;
-      transform: translateX(100vw) !important;
-    }
+.paneSection{}
 
-    &.introduction {
-      font-size: 22px;
-      font-weight: 300;
-    }
-  }
+.pane {
+  padding: 2rem;
+  font-size: 1rem;
+  line-height: 1.333;
+  color: #000;
 
-  .close {
-    position: fixed;
-    top: 27px;
-    right: 27px;
-    width: 60px;
-    height: 60px;
-    padding: 30px;
-    font-size: 72px;
-    color: white;
-    text-align: center;
-    border-radius: 60px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    cursor: pointer;
-    z-index: 10000;
+  padding-top: 80px;
+  padding-bottom: 40px;
 
-    svg {
-      height: 40px;
-      width: 40px;
-      position: relative;
-      top: -5px;
+  position: fixed;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
 
-      transform: rotate(0deg) scale(0);
-      transition: transform 0.5s cubic-bezier(0.23, 1, 0.32, 1);
+  transition: transform .3s ease-out;
 
-      .cls-1 {
-        fill: none;
-      }
+  top: 0;
+  right: 0;
+  width: 100vw;
+  height: 100vh;
+ }
 
-      .cls-2 {
-        clip-path: url(#clip-path);
-      }
+.pane:not(.active){cursor: pointer;}
+.pane.active {transform: translateX(0);}
 
-      .cls-3 {
-        fill: white;
-      }
-    }
+.pane.hidden {
+    transition: transform .3s ease-out;
+    transform: translateX(100%) !important;
+}
 
-    &:hover {
-      svg {
-        color: black;
-      }
-    }
-  }
+.pane.introduction p {
+  font-size: 21.33px;
+  line-height: 1.333;
+  font-weight: normal;
+}
+
+.close {
+  font: inherit;
+  font-size: 72px;
+  line-height: normal;
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  display: block;
+  overflow: visible;
+  width: auto;
+  margin: 0;
+  padding: 0;
+  padding: 30px;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  -webkit-font-smoothing: inherit;
+  -moz-osx-font-smoothing: inherit;
+  -webkit-appearance: none;
+  width: 60px;
+  height: 60px;
+
+  transition: opacity .3s ease;
+}
+
+.close svg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: block;
+  margin-top: -20px;
+  margin-left: -20px;
+  transition: transform 500ms cubic-bezier(0.23, 1, 0.32, 1), fill 200ms ease;
+  transform: rotate(0deg) scale(1);
+  width: 40px;
+  height: 40px;
+  fill: #fff; }
+
+.close:hover svg,
+.close:focus svg,
+.close:active svg {
+  fill: #000; 
+  transform: rotate(180deg) scale(1);
+}
+
+.close:focus,
+.close:active {
+  outline: 0; }
+
+.pane.active + .close{opacity: 1;}
+.pane:not(.active) + .close{opacity: 0;}
 </style>
 
-<div
-  class="pane"
-  style="transform: translateX({left}vw); background: {bgColor};"
-  on:click={open}
-  class:active
-  class:hidden
-  class:introduction={order === 0 && section != 'editorial'}
-  in:fly={{ x: 300, delay: order * 100, opacity: 0 }}>
-  {@html renderBlockText(essay.content)}
-
   <div class="close" on:click={close}>
-    <div class="inner-1">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-        viewBox="0 0 55.46 55.39">
-        <defs>
-          <clipPath id="clip-path" transform="translate(-1.08 -0.65)">
-            <rect
-              class="cls-1"
-              x="1.08"
-              y="0.65"
-              width="55.46"
-              height="55.39" />
-          </clipPath>
-        </defs>
-        <title>cross</title>
-        <g class="cls-2">
-          <path
-            class="cls-3"
-            d="M2.12,49a3.91,3.91,0,0,0-1,2.4,3.08,3.08,0,0,0,1,2.41l1.23,1.23A3.37,3.37,0,0,0,5.69,56a3.12,3.12,0,0,0,2.47-.89L27.38,35.59a1.55,1.55,0,0,1,2.47,0L49.34,54.94A3,3,0,0,0,51.67,56a3.37,3.37,0,0,0,2.47-1.1l1.38-1.23a2.88,2.88,0,0,0,1-2.4,3.62,3.62,0,0,0-1-2.41L36,29.41a1.55,1.55,0,0,1,0-2.47L55.52,7.72a3.18,3.18,0,0,0,.89-2.47,3.45,3.45,0,0,0-.89-2.33L54.28,1.68a3.2,3.2,0,0,0-2.47-1,3.44,3.44,0,0,0-2.33,1L30,20.9a1.4,1.4,0,0,1-2.33,0L8.16,1.68a2.84,2.84,0,0,0-2.27-1,3.51,3.51,0,0,0-2.54,1.1L2.12,2.92a3.21,3.21,0,0,0-1,2.54,3.48,3.48,0,0,0,1,2.4L21.34,27.22a1.66,1.66,0,0,1,0,2.47Z"
-            transform="translate(-1.08 -0.65)" />
-        </g>
-      </svg>
-    </div>
+<section class="paneSection">
+  <div
+    class="pane"
+    style="transform: translateX({left}vw); background: {bgColor};"
+    on:click={open}
+    class:active
+    class:hidden
+    class:introduction={order === 0 && section != 'editorial'}
+    in:fly={{ x: 300, delay: order * 100, opacity: 0 }}>
+    {@html renderBlockText(essay.content)}
   </div>
 
-</div>
+  <button role="button" class="close" on:click={close}>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 55.46 55.39">
+          <path d="M1.04 48.35a3.91 3.91 0 00-1 2.4 3.08 3.08 0 001 2.41l1.23 1.23a3.37 3.37 0 002.34.96 3.12 3.12 0 002.47-.89L26.3 34.94a1.55 1.55 0 012.47 0l19.49 19.35a3 3 0 002.33 1.06 3.37 3.37 0 002.47-1.1l1.38-1.23a2.88 2.88 0 001-2.4 3.62 3.62 0 00-1-2.41L34.92 28.76a1.55 1.55 0 010-2.47L54.44 7.07a3.18 3.18 0 00.89-2.47 3.45 3.45 0 00-.89-2.33L53.2 1.03a3.2 3.2 0 00-2.47-1 3.44 3.44 0 00-2.33 1L28.92 20.25a1.4 1.4 0 01-2.33 0L7.08 1.03a2.84 2.84 0 00-2.27-1 3.51 3.51 0 00-2.54 1.1L1.04 2.27a3.21 3.21 0 00-1 2.54 3.48 3.48 0 001 2.4l19.22 19.36a1.66 1.66 0 010 2.47z"/>
+      </svg>
+      <span class="sr-only">Close Menu</span>
+  </button>
+</section>

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,6 +1,9 @@
 // Sass/scss variable syntax:
 // $variable-name: #fff;
 
+$menu-zindex: 99999;
+
+
 $grey: #656565;
 // $black: rgba(20,20,20,1);
 $black: rgba(0,0,0,1);
@@ -44,6 +47,16 @@ $normal-line-height: 1.3em;
 // $text-stack: 'Wremena', 'times new roman', serif;
 $serif-stack: 'Genath', 'times new roman', serif;
 $sans-stack: 'Antique','helvetica', 'arial', sans-serif;
+
+@mixin size($width, $height: $width) {
+    @if _is-size($height) {
+        height: $height;
+    }
+
+    @if _is-size($width) {
+        width: $width;
+    }
+}
 
 @mixin hide-scroll {
     &::-webkit-scrollbar {
@@ -119,3 +132,89 @@ $sans-stack: 'Antique','helvetica', 'arial', sans-serif;
     }
   }
   
+
+// =================================
+// # Accessibility
+// =================================
+
+.sr-only,
+.sr-only-focusable:active,
+.sr-only-focusable:focus{
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+
+// =================================
+// # Keyframes
+// =================================
+
+@-webkit-keyframes sweep {
+  0% {
+    clip-path: inset(0% 0% 0% 100%);
+    -webkit-clip-path: inset(0% 0% 0% 100%); }
+  50% {
+    clip-path: inset(0% 0% 0% 0%);
+    -webkit-clip-path: inset(0% 0% 0% 0%); }
+  100% {
+    clip-path: inset(0% 100% 0% 0%);
+    -webkit-clip-path: inset(0% 100% 0% 0%); } }
+@keyframes sweep {
+  0% {
+    clip-path: inset(0% 0% 0% 100%);
+    -webkit-clip-path: inset(0% 0% 0% 100%); }
+  50% {
+    clip-path: inset(0% 0% 0% 0%);
+    -webkit-clip-path: inset(0% 0% 0% 0%); }
+  100% {
+    clip-path: inset(0% 100% 0% 0%);
+    -webkit-clip-path: inset(0% 100% 0% 0%); }}
+    
+@-webkit-keyframes sweepMobile {
+  0% {
+    -webkit-clip-path: inset(0% 0% 100% 0%);
+            clip-path: inset(0% 0% 100% 0%); }
+  50% {
+    -webkit-clip-path: inset(0% 0% 0% 0%);
+            clip-path: inset(0% 0% 0% 0%); }
+  100% {
+    -webkit-clip-path: inset(100% 0% 0% 0%);
+            clip-path: inset(100% 0% 0% 0%); } }
+@keyframes sweepMobile {
+  0% {
+    -webkit-clip-path: inset(0% 0% 100% 0%);
+            clip-path: inset(0% 0% 100% 0%); }
+  50% {
+    -webkit-clip-path: inset(0% 0% 0% 0%);
+            clip-path: inset(0% 0% 0% 0%); }
+  100% {
+    -webkit-clip-path: inset(100% 0% 0% 0%);
+            clip-path: inset(100% 0% 0% 0%); } }
+
+@-webkit-keyframes sweepTwo {
+  0% {
+    -webkit-clip-path: inset(0% 100% 0% 0%);
+            clip-path: inset(0% 100% 0% 0%); }
+  50% {
+    -webkit-clip-path: inset(0% 0% 0% 0%);
+            clip-path: inset(0% 0% 0% 0%); }
+  100% {
+    -webkit-clip-path: inset(0% 0% 0% 100%);
+            clip-path: inset(0% 0% 0% 100%); } }
+@keyframes sweepTwo {
+  0% {
+    -webkit-clip-path: inset(0% 100% 0% 0%);
+            clip-path: inset(0% 100% 0% 0%); }
+  50% {
+    -webkit-clip-path: inset(0% 0% 0% 0%);
+            clip-path: inset(0% 0% 0% 0%); }
+  100% {
+    -webkit-clip-path: inset(0% 0% 0% 100%);
+            clip-path: inset(0% 0% 0% 100%); } }

--- a/src/alina-chaiderov/AlinaChaiderov.svelte
+++ b/src/alina-chaiderov/AlinaChaiderov.svelte
@@ -23,7 +23,7 @@
 
   activePage.set("alina");
   orbBackgroundOne.set("rgba(0,0,255,1)");
-  orbBackgroundTwo.set("rgba(0,0,255,1)");
+  orbBackgroundTwo.set("rgba(0,0,0,1)");
   orbColorOne.set("rgba(255,255,255,1)");
   orbColorTwo.set("rgba(255,255,255,1)");
 

--- a/src/olof-marsja/OlofMarsja.svelte
+++ b/src/olof-marsja/OlofMarsja.svelte
@@ -405,7 +405,7 @@
       bind:this={iframeEl} />
 
     <!-- <video src="/img/hacka.mp4" autoplay muted loop /> -->
-    <video class="slipa" src="/img/s2.mp4" autoplay muted loop />
+    <video class="slipa" src="/img/s2.mp4" autoplay muted loop playsinline />
 
     <div class="plate-1">
       <div class="inner">

--- a/src/olof-marsja/OlofMarsja.svelte
+++ b/src/olof-marsja/OlofMarsja.svelte
@@ -405,7 +405,9 @@
       bind:this={iframeEl} />
 
     <!-- <video src="/img/hacka.mp4" autoplay muted loop /> -->
-    <video class="slipa" src="/img/s2.mp4" autoplay muted loop playsinline />
+    <video class="slipa" nocontrols loop muted preload autoplay playsinline>
+      <source src="/img/s2.mp4" type="video/mp4">
+    </video>
 
     <div class="plate-1">
       <div class="inner">

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store'
 
 export const orbBackgroundOne = writable('rgba(0,0,255,1)')
-export const orbBackgroundTwo = writable('rgba(0,0,255,1)')
+export const orbBackgroundTwo = writable('rgba(0,0,0,1)')
 export const orbColorOne = writable('rgba(0,0,0,1)')
 export const orbColorTwo = writable('rgba(255,255,255,1)')
 export const orbPosition = writable({


### PR DESCRIPTION
## Summary:
General improvements to style, syntax, addressed a few minor, and major bugs.

### Scrolling on iOS inside `pane`
I am not sure if this bug is addressed in the current pull request, I will check again once it's merged.

### App.svelte
- General improvement to typography scaling, spacing
- Fixed `img` mobile bug

### Pane.svelte
- Improved syntax to "close" button (accessibility)
- Fixed bug where the button did not appear
- Fixed bug where users would click on `pane` and item will open, on mobile this created a open/close loop when users tried to scroll.

### Orb.svelte
- Changed `background` to `background-color` (across site)
- Moved @kfs to `variables.scss, and improved naming for browser compatability
- General improvements to CSS, to address and fix a couple few bugs

### Menu.svelte
- Improvement to HTML syntax (accessibility, notes below)
- General improvement to CSS, optimized SVG

Before:
```
 <div class="close">
    <div class="inner-1">
      <svg
        xmlns="http://www.w3.org/2000/svg"
        xmlns:xlink="http://www.w3.org/1999/xlink"
        viewBox="0 0 55.46 55.39">
        <defs>
          <clipPath id="clip-path" transform="translate(-1.08 -0.65)">
            <rect
              class="cls-1"
              x="1.08"
              y="0.65"
              width="55.46"
              height="55.39" />
          </clipPath>
        </defs>
        <title>cross</title>
        <g class="cls-2">
          <path
            class="cls-3"
            d="M2.12,49a3.91,3.91,0,0,0-1,2.4,3.08,3.08,0,0,0,1,2.41l1.23,1.23A3.37,3.37,0,0,0,5.69,56a3.12,3.12,0,0,0,2.47-.89L27.38,35.59a1.55,1.55,0,0,1,2.47,0L49.34,54.94A3,3,0,0,0,51.67,56a3.37,3.37,0,0,0,2.47-1.1l1.38-1.23a2.88,2.88,0,0,0,1-2.4,3.62,3.62,0,0,0-1-2.41L36,29.41a1.55,1.55,0,0,1,0-2.47L55.52,7.72a3.18,3.18,0,0,0,.89-2.47,3.45,3.45,0,0,0-.89-2.33L54.28,1.68a3.2,3.2,0,0,0-2.47-1,3.44,3.44,0,0,0-2.33,1L30,20.9a1.4,1.4,0,0,1-2.33,0L8.16,1.68a2.84,2.84,0,0,0-2.27-1,3.51,3.51,0,0,0-2.54,1.1L2.12,2.92a3.21,3.21,0,0,0-1,2.54,3.48,3.48,0,0,0,1,2.4L21.34,27.22a1.66,1.66,0,0,1,0,2.47Z"
            transform="translate(-1.08 -0.65)" />
        </g>
      </svg>
    </div>
  </div>
```

After:
```
<button role="button" class="close">
    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 55.46 55.39">
        <path d="M1.04 48.35a3.91 3.91 0 00-1 2.4 3.08 3.08 0 001 2.41l1.23 1.23a3.37 3.37 0 002.34.96 3.12 3.12 0 002.47-.89L26.3 34.94a1.55 1.55 0 012.47 0l19.49 19.35a3 3 0 002.33 1.06 3.37 3.37 0 002.47-1.1l1.38-1.23a2.88 2.88 0 001-2.4 3.62 3.62 0 00-1-2.41L34.92 28.76a1.55 1.55 0 010-2.47L54.44 7.07a3.18 3.18 0 00.89-2.47 3.45 3.45 0 00-.89-2.33L53.2 1.03a3.2 3.2 0 00-2.47-1 3.44 3.44 0 00-2.33 1L28.92 20.25a1.4 1.4 0 01-2.33 0L7.08 1.03a2.84 2.84 0 00-2.27-1 3.51 3.51 0 00-2.54 1.1L1.04 2.27a3.21 3.21 0 00-1 2.54 3.48 3.48 0 001 2.4l19.22 19.36a1.66 1.66 0 010 2.47z"/>
    </svg>
    <span class="sr-only">Close Menu</span>
</button>
```

### Editorial.svelte, CycleOne.svelte
- Removed unused CSS
- Removed unused classes

### OlofMarsja.svelte
- Added `playsinline` to `video` element, in iOS devices the video was taking over in "native" style. You may want to consider adding this to other video elements.
- Improve `video` syntax